### PR TITLE
fix/json order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 2.0.3
+ - Code cleanup and fixed json order verification is specs
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -10,8 +10,8 @@ require "logstash/namespace"
 #       ruby {
 #         # Cancel 90% of events
 #         code => "event.cancel if rand <= 0.90"
-#       } 
-#     } 
+#       }
+#     }
 #
 class LogStash::Filters::Ruby < LogStash::Filters::Base
   config_name "ruby"
@@ -23,17 +23,13 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
   # You will have an `event` variable available that is the event itself.
   config :code, :validate => :string, :required => true
 
-  public
   def register
     # TODO(sissel): Compile the ruby code
     eval(@init, binding, "(ruby filter init)") if @init
     eval("@codeblock = lambda { |event| #{@code} }", binding, "(ruby filter code)")
-  end # def register
+  end
 
-  public
   def filter(event)
-    
-
     begin
       @codeblock.call(event)
       filter_matched(event)
@@ -41,5 +37,5 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
       @logger.error("Ruby exception occurred: #{e}")
       event.tag("_rubyexception")
     end
-  end # def filter
-end # class LogStash::Filters::Ruby
+  end
+end

--- a/logstash-filter-ruby.gemspec
+++ b/logstash-filter-ruby.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-ruby'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Filter for executing ruby code on the event"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/ruby_spec.rb
+++ b/spec/filters/ruby_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/filters/ruby"
 require "logstash/filters/date"
@@ -25,7 +27,10 @@ describe LogStash::Filters::Ruby do
 
     sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
       # json is rendered in pretty json since the JSON.pretty_generate created json from the event hash
-      insist { subject["pretty"] } == "{\n  \"message\": \"hello world\",\n  \"mydate\": \"2014-09-23T00:00:00-0800\",\n  \"@version\": \"1\",\n  \"@timestamp\": \"2014-09-23T08:00:00.000Z\"\n}"
+      # pretty json contains \n
+      insist { subject["pretty"].count("\n") } == 5
+      # usage of JSON.parse here is to avoid parser-specific order assertions
+      insist { JSON.parse(subject["pretty"]) } == JSON.parse("{\n  \"message\": \"hello world\",\n  \"mydate\": \"2014-09-23T00:00:00-0800\",\n  \"@version\": \"1\",\n  \"@timestamp\": \"2014-09-23T08:00:00.000Z\"\n}")
     end
   end
 
@@ -49,7 +54,10 @@ describe LogStash::Filters::Ruby do
 
     sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
       # if this eventually breaks because we removed the custom to_json and/or added pretty support to JrJackson then all is good :)
-      insist { subject["pretty"] } == "{\"message\":\"hello world\",\"mydate\":\"2014-09-23T00:00:00-0800\",\"@version\":\"1\",\"@timestamp\":\"2014-09-23T08:00:00.000Z\"}"
+      # non-pretty json does not contain \n
+      insist { subject["pretty"].count("\n") } == 0
+      # usage of JSON.parse here is to avoid parser-specific order assertions
+      insist { JSON.parse(subject["pretty"]) } == JSON.parse("{\"message\":\"hello world\",\"mydate\":\"2014-09-23T00:00:00-0800\",\"@version\":\"1\",\"@timestamp\":\"2014-09-23T08:00:00.000Z\"}")
     end
   end
 


### PR DESCRIPTION
- code cleanups
- do not rely on generated json order in specs

relates to elastic/logstash#4264 and elastic/logstash#4191
