### PR TITLE
#fix: increase exception handling verbosity

### DIFF
--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -43,7 +43,10 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
       @codeblock.call(event,&block)
       filter_matched(event)
     rescue Exception => e
-      @logger.error("Ruby exception occurred: #{e}")
+      err_details["exception"] = e
+      err_details["event"] = event
+      err_details["code"] = @code
+      @logger.error("Ruby exception occurred: #{err_details}")
       event.tag("_rubyexception")
     end
   end

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -43,6 +43,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
       @codeblock.call(event,&block)
       filter_matched(event)
     rescue Exception => e
+      err_details = {}
       err_details["exception"] = e
       err_details["event"] = event
       err_details["code"] = @code


### PR DESCRIPTION
Hello all,

I just spent a couple of hours trying to troubleshoot a Ruby Exception error as all my logstash logs told me was:
`"{:timestamp=>"2016-10-06T19:59:22.141000-0300", :message=>"Ruby exception occurred: undefined method '[]' for nil:NilClass", :level=>:error}"`

I really think exception logging should be more verbose like in this example:

 **/opt/logstash/bin/logstash -e 'input{stdin{}}filter{ruby{code => "nil.Ex"}}output{stdout{codec => "rubydebug"}}'**

```
Settings: Default pipeline workers: 2
Pipeline main started
test
Ruby exception occurred: {"exception"=>#<NoMethodError: undefined method `Ex' for nil:NilClass>, "event"=>#<LogStash::Event:0x46637b9d @metadata_accessors=#<LogStash::Util::Accessors:0x3adb2956 @store={}, @lut={}>, @cancelled=false, @data={"message"=>"test", "@version"=>"1", "@timestamp"=>"2016-10-07T12:53:08.775Z", "host"=>"ubuntu"}, @metadata={}, @accessors=#<LogStash::Util::Accessors:0x85d851 @store={"message"=>"test", "@version"=>"1", "@timestamp"=>"2016-10-07T12:53:08.775Z", "host"=>"ubuntu"}, @lut={"host"=>[{"message"=>"test", "@version"=>"1", "@timestamp"=>"2016-10-07T12:53:08.775Z", "host"=>"ubuntu"}, "host"], "message"=>[{"message"=>"test", "@version"=>"1", "@timestamp"=>"2016-10-07T12:53:08.775Z", "host"=>"ubuntu"}, "message"]}>>, "code"=>"nil.Ex"} {:level=>:error}
{
       "message" => "test",
      "@version" => "1",
    "@timestamp" => "2016-10-07T12:53:08.775Z",
          "host" => "ubuntu",
          "tags" => [
        [0] "_rubyexception"
    ]
}

```
