### PR TITLE
add file based scripting to ruby filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Add file base ruby script support
+
 ## 3.0.4
   - Fix some documentation issues
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -20,7 +20,13 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-Execute ruby code.
+Execute ruby code. This filter accepts inline ruby code or a ruby file.
+The two options are mutually exclusive and have slightly different ways of working,
+which are described below.
+
+===== Inline ruby code
+
+To inline ruby in your filter, place all code in the `code` option. This code will be executed for every event the filter receives. You can also place ruby code in the `init` option - it will be executed only once during the plugin's register phase.
 
 For example, to cancel 90% of events, you can do this:
 [source,ruby]
@@ -31,8 +37,7 @@ For example, to cancel 90% of events, you can do this:
       }
     }
 
-If you need to create additional events, it cannot be done as in other filters where you would use `yield`,
-you must use a specific syntax `new_event_block.call(event)` like in this example duplicating the input event
+If you need to create additional events, you must use a specific syntax `new_event_block.call(event)` like in this example duplicating the input event
 [source,ruby]
 filter {
   ruby {
@@ -40,6 +45,92 @@ filter {
   }
 }
 
+===== Using a Ruby script file
+
+As the inline code can become complex and hard to structure inside of a text string in `code`, it's then preferrable to place the Ruby code in a .rb file, using the `path` option.
+
+[source,ruby]
+    filter {
+      ruby {
+        # Cancel 90% of events
+        path => "/etc/logstash/drop_percentage.rb"
+        script_params => { "percentage" => 0.9 }
+      }
+    }
+
+The ruby script file should define the following methods:
+
+ * `register(params)`: An optional register method that receives the key/value hash passed in the `script_params` configuration option
+ * `filter(event)`: A mandatory Ruby method that accepts a Logstash event and must return an array of events
+
+Below is an example implementation of the `drop_percentage.rb` ruby script that drops a configurable percentage of events:
+
+[source,ruby]
+----
+# the value of `params` is the value of the hash passed to `script_params`
+# in the logstash configuration
+def register(params)
+	@drop_percentage = params["percentage"]
+end
+
+# the filter method receives an event and must return a list of events.
+# Dropping an event means not including it in the return array,
+# while creating new ones only requires you to add a new instance of
+# LogStash::Event to the returned array
+def filter(event)
+	if rand >= @drop_percentage
+		return [event]
+	else
+		return [] # return empty array to cancel event
+	end
+end
+----
+
+====== Testing the ruby script
+
+To validate the behaviour of the `filter` method you implemented,
+the Ruby filter plugin provides an inline test framework where you
+can assert expectations.
+The tests you define will run when the pipeline is created and will
+prevent it from starting if a test fails.
+
+You can also verify if the tests pass using the logstash `-t` flag.
+
+For example above, you can write at the bottom of the `drop_percentage.rb`
+ruby script the following test:
+
+[source,ruby]
+----
+def register(params)
+  # ..
+end
+
+def filter(event)
+  # ..
+end
+
+test "drop percentage 100%" do
+  parameters do
+    { "percentage" => 1 }
+  end
+
+  in_event { { "message" => "hello" } }
+
+  expect("drops the event") do |events|
+    events.size == 0
+  end
+end
+----
+
+We can now test that the ruby script we're using is implemented correctly:
+
+[source]
+----
+% bin/logstash -e "filter { ruby { path => '/etc/logstash/drop_percentage.rb' script_params => { 'drop_percentage' => 0.5 } } }" -t
+[2017-10-13T13:44:29,723][INFO ][logstash.filters.ruby.script] Test run complete {:script_path=>"/etc/logstash/drop_percentage.rb", :results=>{:passed=>1, :failed=>0, :errored=>0}}
+Configuration OK
+[2017-10-13T13:44:29,887][INFO ][logstash.runner          ] Using config.test_and_exit mode. Config Validation Result: OK. Exiting Logstash
+----
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Ruby Filter Configuration Options
@@ -49,8 +140,11 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-code>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-code>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-init>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-path>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-script_params>> |<<hash,hash>>,{}|No
+| <<plugins-{type}s-{plugin}-tag_on_exception>> |<<string,string>>,_rubyexception|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -59,24 +153,40 @@ filter plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-code"]
-===== `code` 
+===== `code`
 
-  * This is a required setting.
   * Value type is <<string,string>>
   * There is no default value for this setting.
+	* This setting cannot be used together with `path`.
 
 The code to execute for every event.
 You will have an `event` variable available that is the event itself. See the <<event-api,Event API>> for more information.
 
 [id="plugins-{type}s-{plugin}-init"]
-===== `init` 
+===== `init`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
 Any code to execute at logstash startup-time
 
+[id="plugins-{type}s-{plugin}-path"]
+===== `path`
 
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+	* This setting cannot be used together with `code`.
+
+The path of the ruby script file that implements the `filter` method.
+
+[id="plugins-{type}s-{plugin}-script_params"]
+===== `script_params`
+
+  * Value type is <<hash,hash>>
+  * Default value is `{}`
+
+A key/value hash with parameters that are passed to the register method
+of your ruby script file defined in `path`.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -23,6 +23,9 @@ require "logstash/namespace"
 # }
 #
 class LogStash::Filters::Ruby < LogStash::Filters::Base
+  require "logstash/filters/ruby/script_error"
+  require "logstash/filters/ruby/script"
+
   config_name "ruby"
 
   # Any code to execute at logstash startup-time
@@ -30,21 +33,92 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
 
   # The code to execute for every event.
   # You will have an `event` variable available that is the event itself. See the <<event-api,Event API>> for more information.
-  config :code, :validate => :string, :required => true
+  config :code, :validate => :string
+
+  # Path to the script
+  config :path, :validate => :path
+
+  # Parameters for this specific script
+  config :script_params, :type => :hash, :default => {}
+
+  # Tag to add to events that cause an exception in the script filter
+  config :tag_on_exception, :type => :string, :default => "_rubyexception"
+
+  def initialize(*params)
+    super(*params)
+    if @path # run tests on the ruby file script
+      @script = Script.new(@path, @script_params)
+      @script.load
+      @script.test
+    end
+  end
 
   def register
-    # TODO(sissel): Compile the ruby code
-    eval(@init, binding, "(ruby filter init)") if @init
-    eval("@codeblock = lambda { |event, &new_event_block| #{@code} }", binding, "(ruby filter code)")
-  end # def register
-
-  def filter(event,&block)
-    begin
-      @codeblock.call(event,&block)
-      filter_matched(event)
-    rescue Exception => e
-      @logger.error("Ruby exception occurred: #{e}")
-      event.tag("_rubyexception")
+    if @code && @path.nil?
+      eval(@init, binding, "(ruby filter init)") if @init
+      eval("@codeblock = lambda { |event, &new_event_block| #{@code} }", binding, "(ruby filter code)")
+    elsif @path && @code.nil?
+      @script.register
+    else
+      @logger.fatal("You must either use an inline script with the \"code\" option or a script file using \"path\".")
     end
+  end
+
+  def self.check_result_events!(results)
+    if !results.is_a?(Array)
+      raise "Custom script did not return an array from 'filter'. Only arrays may be returned!"
+    end
+
+    results.each do |r_event|
+      if !r_event.is_a?(::LogStash::Event)
+        raise "Custom script returned a non event object '#{r_event.inspect}'!" +
+              " You must an array of events from this function! To drop an event simply return nil."
+      end
+    end
+  end
+
+  def filter(event, &block)
+    if @code
+      inline_script(event, &block)
+    elsif @path
+      file_script(event)
+    end
+  end
+
+  def inline_script(event, &block)
+    @codeblock.call(event, &block)
+    filter_matched(event)
+  rescue Exception => e
+    @logger.error("Ruby exception occurred: #{e}")
+    event.tag(@tag_on_exception)
+  end
+
+  def file_script(event)
+    begin
+      results = @script.execute(event)
+
+      self.class.check_result_events!(results)
+    rescue => e
+      event.tag(@tag_on_exception)
+      message = "Could not process event: " + e.message
+      @logger.error(message, :script_path => @path,
+                             :class => e.class.name,
+                             :backtrace => e.backtrace)
+      return event
+    end
+
+    returned_original = false
+    results.each do |r_event|
+      # If the user has generated a new event we yield that for them here
+      if event == r_event
+        returned_original = true
+      else
+        yield r_event
+      end
+
+      r_event
+    end
+
+    event.cancel unless returned_original
   end
 end

--- a/lib/logstash/filters/ruby/script.rb
+++ b/lib/logstash/filters/ruby/script.rb
@@ -1,0 +1,40 @@
+class LogStash::Filters::Ruby::Script
+  include ::LogStash::Util::Loggable
+  require "logstash/filters/ruby/script/context"
+
+  attr_reader :content, :script_path
+
+  def initialize(script_path, parameters)
+    @content = File.read(script_path)
+    @script_path = script_path
+    @context = Context.new(self, parameters)
+  end
+
+  def load
+    @context.load_script
+
+    if !@context.execution_context.methods.include?(:filter)
+      raise "Script does not define a filter! Please ensure that you have defined a filter method!"
+    end
+  rescue => e
+    raise ::LogStash::Filters::Ruby::ScriptError.new("Error during load of '#{script_path}': #{e.inspect}")
+  end
+
+  def register
+    @context.execute_register
+  rescue => e
+    raise ::LogStash::Filters::Ruby::ScriptError.new("Error during register of '#{script_path}': #{e.inspect}")
+  end
+
+  def execute(event)
+    @context.execute_filter(event)
+  end
+
+  def test
+    results = @context.execute_tests
+    logger.info("Test run complete", :script_path => script_path, :results => results)
+    if results[:failed] > 0 || results[:errored] > 0
+      raise ::LogStash::Filters::Ruby::ScriptError.new("Script '#{script_path}' had #{results[:failed] + results[:errored]} failing tests! Check the error log for details.")
+    end
+  end
+end

--- a/lib/logstash/filters/ruby/script/context.rb
+++ b/lib/logstash/filters/ruby/script/context.rb
@@ -1,0 +1,75 @@
+class LogStash::Filters::Ruby::Script::Context
+  require "logstash/filters/ruby/script/execution_context"
+  require "logstash/filters/ruby/script/test_context"
+
+  include ::LogStash::Util::Loggable
+
+  attr_reader :script,
+              :execution_context
+
+  def initialize(script, parameters)
+    @script = script
+    @script_path = @script.script_path
+    @parameters = parameters
+    @test_contexts = []
+    @script_lock = Mutex.new
+    @concurrency = :single
+  end
+
+  def make_execution_context(name, test_mode)
+    execution_context = LogStash::Filters::Ruby::Script::ExecutionContext.new(name, logger)
+
+    # Proxy all the methods from this instance needed to be run from the execution context
+    this = self # We need to use a clojure to retain access to this object
+    # If we aren't in test mode we define the test. If we *are* then we don't define anything
+    # since our tests are already defined
+    if test_mode
+      execution_context.define_singleton_method(:test) {|name,&block| nil }
+    else
+      execution_context.define_singleton_method(:test) {|name,&block| this.test(name, &block) }
+    end
+    execution_context
+  end
+
+  def load_execution_context(ec)
+    ec.instance_eval(@script.content, @script_path, 1)
+  end
+
+  def load_script
+    @execution_context = self.make_execution_context(:main, false)
+    load_execution_context(@execution_context)
+  end
+
+  def execute_register()
+    @execution_context.register(@parameters)
+  end
+
+  def concurrency(type)
+    @concurrency = type
+  end
+
+  def execute_filter(event)
+    if @concurrency == :shared
+      @script_lock.synchronize { @execution_context.filter(event) }
+    else
+      @execution_context.filter(event)
+    end
+  end
+
+  def execute_tests
+    @test_contexts.
+      map(&:execute).
+      reduce({:passed => 0, :failed => 0, :errored => 0}) do |acc,res|
+        acc[:passed] += res[:passed]
+        acc[:failed] += res[:failed]
+        acc[:errored] += res[:errored]
+        acc
+      end
+  end
+
+  def test(name, &block)
+    test_context = LogStash::Filters::Ruby::Script::TestContext.new(self, name)
+    test_context.instance_eval(&block)
+    @test_contexts << test_context
+  end
+end

--- a/lib/logstash/filters/ruby/script/execution_context.rb
+++ b/lib/logstash/filters/ruby/script/execution_context.rb
@@ -1,0 +1,24 @@
+# A blank area for our script to live in.
+# Everything is instance_e{val,exec}'d against this
+# to eliminate instance var and method def conflicts against other
+# objects
+class LogStash::Filters::Ruby::Script::ExecutionContext
+  def initialize(name, logger)
+    # Namespaced with underscore so as not to conflict with anything the user sets
+    @__name__ = name
+    @__logger__ = logger
+  end
+
+  def logger
+    @__logger__
+  end
+
+  def register(params)
+    logger.debug("skipping register since the script didn't define it")
+  end
+
+  def to_s
+    "<ExecutionContext #{@__name__}>"
+  end
+end
+

--- a/lib/logstash/filters/ruby/script/expect_context.rb
+++ b/lib/logstash/filters/ruby/script/expect_context.rb
@@ -1,0 +1,40 @@
+# Handle expect blocks inside of test blocks
+class ExpectContext
+  include ::LogStash::Util::Loggable
+
+  attr_reader :name
+
+  def initialize(test_context, name, block)
+    @test_context = test_context
+    @name = name
+    @block = block
+  end
+
+  def to_s
+    "<Expect #{@test_context.name}/#{self.name}>"
+  end
+
+  def execute(events)
+    begin
+      if @block.call(events)
+        return :passed
+      else
+        result = :failed
+        message = "***TEST FAILURE FOR: '#{@test_context.name} #{@name}'***"
+        log_hash = {}
+      end
+    rescue => e
+      result = :errored
+      message = "***TEST RAISED ERROR: '#{@test_context.name} #{@name}'***"
+      log_hash = { "exception" => e.inspect, "backtrace" => e.backtrace }
+    end
+    script_path = @test_context.script_context.script.script_path
+    log_hash.merge!({
+      :parameters => @test_context.parameters,
+      :in_events => @test_context.in_events.map(&:to_hash_with_metadata),
+      :results => events.map(&:to_hash_with_metadata)
+    })
+    logger.error(message, log_hash)
+    result
+  end
+end

--- a/lib/logstash/filters/ruby/script/test_context.rb
+++ b/lib/logstash/filters/ruby/script/test_context.rb
@@ -1,0 +1,65 @@
+# Handle top level test blocks
+class LogStash::Filters::Ruby::Script::TestContext
+  require "logstash/filters/ruby/script/expect_context"
+  attr_reader :name, :script_context
+
+  def initialize(script_context, name)
+    @name = name
+    @script_context = script_context
+    @expect_contexts = []
+    @parameters = {}
+    @execution_context = script_context.make_execution_context("Test/#{name}", true)
+    @script_context.load_execution_context(@execution_context)
+  end
+
+  def parameters(&block)
+    # Can act as a reader if no block passed
+    return @parameters unless block
+
+    @parameters = block.call
+    if !@parameters.is_a?(Hash)
+      raise ArgumentError, "Test parameters must be a hash in #{@name}!"
+    end
+
+    @execution_context.register(@parameters)
+  end
+
+  def in_event(&block)
+    return @in_events unless block
+
+    orig = block.call
+    event_hashes = orig.is_a?(Hash) ? [orig] : orig
+    event_hashes.each do |e|
+      if !e.is_a?(Hash)
+        raise ArgumentError,
+          "In event for #{self.name} must receive either a hash or an array of hashes! got a '#{e.class}' in #{event_hashes.inspect}"
+      end
+    end
+    @in_events = Array(event_hashes).map {|h| ::LogStash::Event.new(h) }
+  end
+  alias_method :in_events, :in_event
+
+  def execute
+    if !@in_events
+      raise "You must declare an `in_event` to run tests!"
+    end
+
+    results = []
+    @in_events.each do |e|
+      single_result = @execution_context.filter(e)
+      ::LogStash::Filters::Ruby.check_result_events!(single_result)
+      results += single_result
+    end
+
+    @expect_contexts.map do |ec|
+      ec.execute(results)
+    end.reduce({:passed => 0, :failed => 0, :errored => 0}) do |acc,res|
+      acc[res] += 1
+      acc
+    end
+  end
+
+  def expect(name, &block)
+    @expect_contexts << ExpectContext.new(self, name, block)
+  end
+end

--- a/lib/logstash/filters/ruby/script_error.rb
+++ b/lib/logstash/filters/ruby/script_error.rb
@@ -1,0 +1,2 @@
+class LogStash::Filters::Ruby::ScriptError < StandardError
+end

--- a/logstash-filter-ruby.gemspec
+++ b/logstash-filter-ruby.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-ruby'
-  s.version         = '3.0.4'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Filter for executing ruby code on the event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/ruby_spec.rb
+++ b/spec/filters/ruby_spec.rb
@@ -1,121 +1,160 @@
 # encoding: utf-8
-
-require "logstash/devutils/rspec/spec_helper"
+require_relative '../spec_helper'
 require "logstash/filters/ruby"
 require "logstash/filters/date"
 
 describe LogStash::Filters::Ruby do
+  context "when using inline script" do
+    describe "generate pretty json on event.to_hash" do
+      # this obviously tests the Ruby filter but also makes sure
+      # the fix for issue #1771 is correct and that to_json is
+      # compatible with the json gem convention.
 
-  describe "generate pretty json on event.to_hash" do
-    # this obviously tests the Ruby filter but also makes sure
-    # the fix for issue #1771 is correct and that to_json is
-    # compatible with the json gem convention.
-
-    config <<-CONFIG
-      filter {
-        date {
-          match => [ "mydate", "ISO8601" ]
-          locale => "en"
-          timezone => "UTC"
+      config <<-CONFIG
+        filter {
+          date {
+            match => [ "mydate", "ISO8601" ]
+            locale => "en"
+            timezone => "UTC"
+          }
+          ruby {
+            init => "require 'json'"
+            code => "event.set('pretty', JSON.pretty_generate(event.to_hash))"
+          }
         }
-        ruby {
-          init => "require 'json'"
-          code => "event.set('pretty', JSON.pretty_generate(event.to_hash))"
-        }
-      }
-    CONFIG
+      CONFIG
 
-    sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
-      # json is rendered in pretty json since the JSON.pretty_generate created json from the event hash
-      # pretty json contains \n
-      insist { subject.get("pretty").count("\n") } == 5
-      # usage of JSON.parse here is to avoid parser-specific order assertions
-      insist { JSON.parse(subject.get("pretty")) } == JSON.parse("{\n  \"message\": \"hello world\",\n  \"mydate\": \"2014-09-23T00:00:00-0800\",\n  \"@version\": \"1\",\n  \"@timestamp\": \"2014-09-23T08:00:00.000Z\"\n}")
+      sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
+        # json is rendered in pretty json since the JSON.pretty_generate created json from the event hash
+        # pretty json contains \n
+        insist { subject.get("pretty").count("\n") } == 5
+        # usage of JSON.parse here is to avoid parser-specific order assertions
+        insist { JSON.parse(subject.get("pretty")) } == JSON.parse("{\n  \"message\": \"hello world\",\n  \"mydate\": \"2014-09-23T00:00:00-0800\",\n  \"@version\": \"1\",\n  \"@timestamp\": \"2014-09-23T08:00:00.000Z\"\n}")
+      end
+    end
+
+    describe "generate pretty json on event.to_hash" do
+      # this obviously tests the Ruby filter but asses that using the json gem directly
+      # on even will correctly call the to_json method but will use the logstash json
+      # generation and thus will not work with pretty_generate.
+      config <<-CONFIG
+        filter {
+          date {
+            match => [ "mydate", "ISO8601" ]
+            locale => "en"
+            timezone => "UTC"
+          }
+          ruby {
+            init => "require 'json'"
+            code => "event.set('pretty', JSON.pretty_generate(event))"
+          }
+        }
+      CONFIG
+
+      sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
+        # if this eventually breaks because we removed the custom to_json and/or added pretty support to JrJackson then all is good :)
+        # non-pretty json does not contain \n
+        insist { subject.get("pretty").count("\n") } == 0
+        # usage of JSON.parse here is to avoid parser-specific order assertions
+        insist { JSON.parse(subject.get("pretty")) } == JSON.parse("{\"message\":\"hello world\",\"mydate\":\"2014-09-23T00:00:00-0800\",\"@version\":\"1\",\"@timestamp\":\"2014-09-23T08:00:00.000Z\"}")
+      end
+    end
+
+    describe "catch all exceptions and don't let them ruin your day buy stopping the entire worker" do
+      # If exception is raised, it stops entine processing pipeline, and never resumes
+      # Code section should always be wrapped with begin/rescue
+      config <<-CONFIG
+        filter {
+          date {
+            match => [ "mydate", "ISO8601" ]
+            locale => "en"
+            timezone => "UTC"
+          }
+          ruby {
+            init => "require 'json'"
+            code => "raise 'You shall not pass'"
+            add_tag => ["ok"]
+          }
+        }
+      CONFIG
+
+      sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
+        insist { subject.get("mydate") } == "2014-09-23T00:00:00-0800"
+        insist { subject.get("tags") } == ["_rubyexception"]
+      end
+    end
+
+    describe "allow to create new event inside the ruby filter" do
+      config <<-CONFIG
+        filter {
+          ruby {
+            code => "new_event_block.call(event.clone)"
+          }
+        }
+      CONFIG
+
+      sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
+        expect(subject).to be_a Array
+        expect(subject[0]).not_to eq(subject[1])
+        expect(subject[0].to_hash).to eq(subject[1].to_hash)
+      end
+    end
+
+    describe "allow to replace event by another one" do
+      config <<-CONFIG
+        filter {
+          ruby {
+            code => "new_event_block.call(event.clone);
+                     event.cancel;"
+            add_tag => ["ok"]
+          }
+        }
+      CONFIG
+
+      sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
+        expect(subject.get("message")).to eq("hello world");
+        expect(subject.get("mydate")).to eq("2014-09-23T00:00:00-0800");
+      end
     end
   end
 
-  describe "generate pretty json on event.to_hash" do
-    # this obviously tests the Ruby filter but asses that using the json gem directly
-    # on even will correctly call the to_json method but will use the logstash json
-    # generation and thus will not work with pretty_generate.
-    config <<-CONFIG
-      filter {
-        date {
-          match => [ "mydate", "ISO8601" ]
-          locale => "en"
-          timezone => "UTC"
-        }
-        ruby {
-          init => "require 'json'"
-          code => "event.set('pretty', JSON.pretty_generate(event))"
-        }
-      }
-    CONFIG
+  context "when using file based script" do
+    let(:fixtures_path) { File.join(File.dirname(__FILE__), '../fixtures/') }
+    let(:script_filename) { 'field_multiplier.rb' }
+    let(:script_path) { File.join(fixtures_path, script_filename)}
+    let(:script_params) { { 'field' => 'foo', 'multiplier' => 2 } }
+    let(:filter_params) { { 'path' => script_path, 'script_params' => script_params} }
+    let(:incoming_event) { ::LogStash::Event.new('foo' => 42) }
 
-    sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
-      # if this eventually breaks because we removed the custom to_json and/or added pretty support to JrJackson then all is good :)
-      # non-pretty json does not contain \n
-      insist { subject.get("pretty").count("\n") } == 0
-      # usage of JSON.parse here is to avoid parser-specific order assertions
-      insist { JSON.parse(subject.get("pretty")) } == JSON.parse("{\"message\":\"hello world\",\"mydate\":\"2014-09-23T00:00:00-0800\",\"@version\":\"1\",\"@timestamp\":\"2014-09-23T08:00:00.000Z\"}")
+    subject(:filter) { ::LogStash::Filters::Ruby.new(filter_params) }
+
+    describe "basics" do
+      it "should register cleanly" do
+        expect do
+          filter.register
+        end.not_to raise_error
+      end
+
+      describe "filtering" do
+        before(:each) do
+          filter.register
+          filter.filter(incoming_event)
+        end
+
+        it "should filter data as expected" do
+          expect(incoming_event.get('foo')).to eq(84)
+        end
+      end
     end
-  end
 
-  describe "catch all exceptions and don't let them ruin your day buy stopping the entire worker" do
-    # If exception is raised, it stops entine processing pipeline, and never resumes
-    # Code section should always be wrapped with begin/rescue
-    config <<-CONFIG
-      filter {
-        date {
-          match => [ "mydate", "ISO8601" ]
-          locale => "en"
-          timezone => "UTC"
-        }
-        ruby {
-          init => "require 'json'"
-          code => "raise 'You shall not pass'"
-          add_tag => ["ok"]
-        }
-      }
-    CONFIG
+    describe "scripts with failing test suites" do
+      let(:script_filename) { 'broken.rb' }
 
-    sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
-      insist { subject.get("mydate") } == "2014-09-23T00:00:00-0800"
-      insist { subject.get("tags") } == ["_rubyexception"]
-    end
-  end
-
-  describe "allow to create new event inside the ruby filter" do
-    config <<-CONFIG
-      filter {
-        ruby {
-          code => "new_event_block.call(event.clone)"
-        }
-      }
-    CONFIG
-
-    sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
-      expect(subject).to be_a Array
-      expect(subject[0]).not_to eq(subject[1])
-      expect(subject[0].to_hash).to eq(subject[1].to_hash)
-    end
-  end
-
-  describe "allow to replace event by another one" do
-    config <<-CONFIG
-      filter {
-        ruby {
-          code => "new_event_block.call(event.clone);
-                   event.cancel;"
-          add_tag => ["ok"]
-        }
-      }
-    CONFIG
-
-    sample("message" => "hello world", "mydate" => "2014-09-23T00:00:00-0800") do
-      expect(subject.get("message")).to eq("hello world");
-      expect(subject.get("mydate")).to eq("2014-09-23T00:00:00-0800");
+      it "should error out during register" do
+        expect do
+          filter.register
+        end.to raise_error(LogStash::Filters::Ruby::ScriptError)
+      end
     end
   end
 end
-

--- a/spec/fixtures/broken.rb
+++ b/spec/fixtures/broken.rb
@@ -1,0 +1,13 @@
+def filter(event)
+  event.set('foo', 'bar')
+  [event]
+end
+
+test "setting the field" do
+  in_event { { "myfield" => 123 } }
+
+  # This should fail!
+  expect("foo to equal baz") do |events|
+    events.first.get('foo') == 'baz'
+  end
+end

--- a/spec/fixtures/field_multiplier.rb
+++ b/spec/fixtures/field_multiplier.rb
@@ -1,0 +1,34 @@
+# Disables mutex around the `filter` function
+# Only use this if you know your code is threadsafe!
+def concurrency
+  :shared
+end
+
+def register(params)
+  @field = params['field']
+  @multiplier = params['multiplier']
+end
+
+def filter(event)
+  event.set(@field, event.get(@field) * @multiplier)
+  # Filter blocks must return any events that are to be passed on
+  # return a nil or [] here if all events are to be cancelled
+  # You can even return one or more brand new events here!
+  [event]
+end
+
+test "standard flow" do
+  parameters do
+    { "field" => "myfield", "multiplier" => 3 }
+  end
+
+  in_event { { "myfield" => 123 } }
+
+  expect("there to be only one result event") do |events|
+    events.size == 1
+  end
+
+  expect("result to be equal to 123*3(369)") do |events|
+    events.first.get("myfield") == 369
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"


### PR DESCRIPTION
This PR adds two new options: `path` and `parameters`, and these options are mutually exclusive with the existing `init`/`code`.

This allows a user to place the ruby code in a file instead of inlining it in the logstash configuration.

This is based off of @andrewvc's work on https://github.com/logstash-plugins/logstash-filter-script/pull/1

~~This PR is still a WIP as some edge cases haven't been dealt with, user experience is still not great, and lacks documentation updates.~~

This PR is ready for review.
