### PR TITLE
BUG: Fix concurrency issues arising from sharing lambda across worker threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+  - Fix concurrency issues in combination with Logstash 6.x and multiple worker threads that was caused by a [JRuby issue](https://github.com/jruby/jruby/issues/4868)
+
 ## 3.1.1
   - Update gemspec summary
 

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -56,7 +56,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
   def register
     if @code && @path.nil?
       eval(@init, binding, "(ruby filter init)") if @init
-      eval("@codeblock = lambda { |event, &new_event_block| #{@code} }", binding, "(ruby filter code)")
+      eval("define_singleton_method :filter_method do |event, &new_event_block|\n #{@code} \nend", binding, "(ruby filter code)")
     elsif @path && @code.nil?
       @script.register
     else
@@ -86,7 +86,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
   end
 
   def inline_script(event, &block)
-    @codeblock.call(event, &block)
+    filter_method(event, &block)
     filter_matched(event)
   rescue Exception => e
     @logger.error("Ruby exception occurred: #{e}")

--- a/logstash-filter-ruby.gemspec
+++ b/logstash-filter-ruby.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-ruby'
-  s.version         = '3.1.1'
+  s.version         = '3.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Executes arbitrary Ruby code"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes https://github.com/elastic/logstash/issues/8727 by using a dynamically defined method instead of a dynamically defined lambda for the user-configured code.

For an explanation as to why this fixes the issue, see https://github.com/jruby/jruby/issues/4868#issuecomment-347354756