### PR TITLE
Add exception message to event

### DIFF
--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -45,7 +45,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
   config :tag_on_exception, :type => :string, :default => "_rubyexception"
 
   # Flag for add exception message to tag_on_exception
-  config :enable_exception_message, :type => :boolean, :default => false
+  config :tag_with_exception_message, :type => :boolean, :default => false
 
   def initialize(*params)
     super(*params)
@@ -93,7 +93,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
     filter_matched(event)
   rescue Exception => e
     @logger.error("Ruby exception occurred: #{e}")
-    if @enable_exception_message
+    if @tag_with_exception_message
       event.tag("#{@tag_on_exception}: #{e}")
     end
     event.tag(@tag_on_exception)
@@ -106,7 +106,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
 
       self.class.check_result_events!(results)
     rescue => e
-      if @enable_exception_message
+      if @tag_with_exception_message
         event.tag("#{@tag_on_exception}: #{e}")
       end
       event.tag(@tag_on_exception)

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -45,7 +45,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
   config :tag_on_exception, :type => :string, :default => "_rubyexception"
 
   # Flag for add exception message to tag_on_exception
-  config :enable_exception_message, :type => :boolean, :default => true
+  config :enable_exception_message, :type => :boolean, :default => false
 
   def initialize(*params)
     super(*params)

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -44,7 +44,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
   # Tag to add to events that cause an exception in the script filter
   config :tag_on_exception, :type => :string, :default => "_rubyexception"
 
-  # Tlag for add exception message to tag_on_exception
+  # Flag for add exception message to tag_on_exception
   config :enable_exception_message, :type => :boolean, :default => true
 
   def initialize(*params)

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -103,6 +103,7 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
   def file_script(event)
     begin
       results = @script.execute(event)
+      filter_matched(event)
 
       self.class.check_result_events!(results)
     rescue => e

--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -94,10 +94,9 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
   rescue Exception => e
     @logger.error("Ruby exception occurred: #{e}")
     if @enable_exception_message
-      event.tag(@tag_on_exception + ": " + e.to_s)
-    else
-      event.tag(@tag_on_exception)
+      event.tag("#{@tag_on_exception}: #{e}")
     end
+    event.tag(@tag_on_exception)
   end
 
   def file_script(event)
@@ -108,10 +107,9 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
       self.class.check_result_events!(results)
     rescue => e
       if @enable_exception_message
-        event.tag(@tag_on_exception + ": " + e.to_s)
-      else
-        event.tag(@tag_on_exception)
+        event.tag("#{@tag_on_exception}: #{e}")
       end
+      event.tag(@tag_on_exception)
       message = "Could not process event: " + e.message
       @logger.error(message, :script_path => @path,
                              :class => e.class.name,


### PR DESCRIPTION
Exceptions may be thrown when working with ruby filter.
Now the event logs only the fact that there was an exception, but it is not informative.

https://discuss.elastic.co/t/filter-ruby-plugin-how-to-add-exception-message-to-event/154813