### PR TITLE
add backtrace to error output for inline scripts

### DIFF
--- a/lib/logstash/filters/ruby.rb
+++ b/lib/logstash/filters/ruby.rb
@@ -92,7 +92,9 @@ class LogStash::Filters::Ruby < LogStash::Filters::Base
     filter_method(event, &block)
     filter_matched(event)
   rescue Exception => e
-    @logger.error("Ruby exception occurred: #{e}")
+    @logger.error("Ruby exception occurred: #{e.message}",
+                  :class     => e.class.name,
+                  :backtrace => e.backtrace)
     if @tag_with_exception_message
       event.tag("#{@tag_on_exception}: #{e}")
     end


### PR DESCRIPTION
mirrors the behaviour of errors in the file-based scripts