### PR TITLE
[DOC] Correct description of `tag_with_exception_message`

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -229,7 +229,7 @@ causes an exception.
 * Value type is <<boolean,boolean>>
 * Default value is `false`
 
-If `true` adds a tag to the event that is the concatenation of `tag_with_exception_message`
+If `true` adds a tag to the event that is the concatenation of `tag_on_exception`
 and the exception message.
 
 


### PR DESCRIPTION
Based on https://github.com/logstash-plugins/logstash-filter-ruby/blob/32c5f6c9efeaa041dd98ffbc4b7665204c88e2dd/lib/logstash/filters/ruby.rb#L102-L104